### PR TITLE
Fix MPSSI crashes with multi-spin states (closes #36)

### DIFF
--- a/dmrg/framework/dmrg/mp_tensors/mps_rotate.h
+++ b/dmrg/framework/dmrg/mp_tensors/mps_rotate.h
@@ -318,6 +318,24 @@ namespace mps_rotate
             // compression of MPS'
             compress_mps<Matrix, SymmGroup>(mps_prime, "MPS prime");
 
+            // Guard: if the first correction vanishes or becomes NaN after compression,
+            // applying the MPO to it produces mps_prime_prime with disconnected charge sectors
+            // or NaN tensors; the subsequent join/multiply_by_scalar causes a SIGSEGV
+            // (qcscine/qcmaquis#36). A negligible/NaN first correction implies a negligible
+            // second correction, so skip both.
+            // NOTE: use !(>= threshold) instead of (< threshold) to also catch NaN, since
+            // IEEE 754 defines NaN < x == false for any x, bypassing a plain < guard.
+            if (!(norm(mps_prime) >= 1e-14)) {
+                compress_mps<Matrix, SymmGroup>(mps, "MPS final");
+                typename Matrix::value_type n = norm(mps_prime);
+                if (std::isnan(n))
+                    maquis::cout << "-  First correction is NaN after compression (degenerate charge sectors); skipping second correction  -" << std::endl;
+                else
+                    maquis::cout << "-  First correction negligible (norm=" << n << " < 1e-14); skipping second correction  -" << std::endl;
+                maquis::cout << "-  Final (for the current site to be rotated) MPS with full compression - " << std::endl;
+                continue;
+            }
+
             //maquis::cout << "- enter for second correction - "<<      std::endl;
             // |mps''> = H|mps'> (second correction vector)
             mps_prime_prime = MPS_sigma_vector_product<Matrix, SymmGroup>(mps_prime, MPO_vec);

--- a/dmrg/lib/maquis_dmrg/mpssi_interface.cpp
+++ b/dmrg/lib/maquis_dmrg/mpssi_interface.cpp
@@ -147,11 +147,12 @@ namespace maquis
             // Find out about the spin multiplicity required in the 2U1 filename
             // by loading the parameters from the SU2U1 file
 
-            for (int i = 0; i < project_names.size(); i++)
+            // Pass 1: collect nel_ and multiplicities_ for all projects before generating 2U1 checkpoints.
+            // This is necessary because generating 2U1 checkpoints for project i requires knowing the
+            // multiplicities of ALL other projects j (to determine the required Ms projections),
+            // but in a single-pass loop multiplicities_[j] for j > i would still be 0 (uninitialized).
+            for (int i = 0; i < (int)project_names.size(); i++)
             {
-                // Load the first state of each project group and get its number of electrons and spin.
-                // We will not check if the subsequent states have the same spin for now, but if you want to implement if for better
-                // error safety, feel free.
                 const std::string& pname = project_names[i];
                 assert(states[i].size() > 0); // make sure we do not have empty state containers
                 int state = states[i][0];
@@ -171,6 +172,12 @@ namespace maquis
                     throw std::runtime_error("Different electron numbers in different project groups: This is not supported in MPSSI yet.");
                 nel_ = nel;
                 multiplicities_[i] = parms["spin"];
+            }
+
+            // Pass 2: now that all multiplicities are known, generate 2U1 checkpoints for each project.
+            for (int i = 0; i < (int)project_names.size(); i++)
+            {
+                const std::string& pname = project_names[i];
 
                 // transform all checkpoints to 2U1 point group
                 for (auto&& st: states[i])
@@ -180,7 +187,7 @@ namespace maquis
                     // so we create a list with these Ms values
                     int min_tmp = multiplicities_[i];
                     std::vector<int> mult_totransform{min_tmp};
-                    for (int j = 0; j < project_names.size(); j++)
+                    for (int j = 0; j < (int)project_names.size(); j++)
                     {
                         if (min_tmp > std::min(multiplicities_[j], min_tmp))
                         {
@@ -191,7 +198,6 @@ namespace maquis
 
                     for (auto&& m: mult_totransform)
                         maquis::transform(pname, st, m);
-
                 }
             }
         }


### PR DESCRIPTION
## Summary

Two bugs in the `nag-compiler-fix-internal` branch cause SIGSEGV or `archive_not_found` whenever MPSSI combines states from more than one spin multiplicity (e.g. quintet + triplet + singlet). Both are fixed here.

This PR targets `nag-compiler-fix-internal` because that is the branch currently pinned by OpenMolcas master (`15bc02d80c`), and the bugs affect all OpenMolcas users of MPSSI with multi-spin NEVPT2 states.

---

## Bug A: `mpssi_interface.cpp`: single-pass constructor reads uninitialized multiplicities

The `Impl` constructor iterated over projects in a single pass, setting `multiplicities_[i]` and immediately reading `multiplicities_[j]` for `j > i` to determine the minimum multiplicity (needed for TwoU1 checkpoint naming). For `j > i`, `multiplicities_[j]` was still zero (default-initialized), so `min_multiplicity = 0`, generating TwoU1 checkpoint filenames that do not exist → `archive_not_found`.

**Fix:** two-pass loop. Pass 1 collects `nel_` and `multiplicities_` for all projects. Pass 2 generates TwoU1 checkpoints once all multiplicities are known.

## Bug B: `mps_rotate.h`: NaN compression trace bypasses norm guard

After `compress_mps(mps_prime)`, the compression trace can be NaN when the MPS has near-zero overlap with the new basis, a physically legitimate situation when charge sectors from different spin multiplicities are incompatible. The original guard:
```cpp
if (norm(mps_prime) < 1e-14)
```
silently fails for NaN because IEEE 754 defines `NaN < x == false` for any `x`. The NaN-contaminated MPS is then used in `MPS_sigma_vector_product` → SIGSEGV.

**Fix:**
```cpp
if (!(norm(mps_prime) >= 1e-14))
```
This catches both near-zero and NaN.

---

## Testing

Tested with OpenMolcas master (`15bc02d80c`) + `nag-compiler-fix-internal`:

| System | Basis | Active space | States | Result |
|--------|-------|-------------|--------|--------|
| C2H2 | cc-pVDZ | CAS(4,4) | 3×(quintet+triplet+singlet) + NEVPT2/QDSC | ✅ PASS (was SIGSEGV) |
| Po₂ | ANO-RCC-VQZP | CAS(12,8) | 3×(quintet+triplet+singlet) + NEVPT2/QDSC | ✅ PASS (27 SO states, Ω=0 ground state) |

Tests 016/017 in the OpenMolcas test suite confirmed SIGSEGV without this patch and pass with it. The companion OpenMolcas MR (Bugs C/D in `mktdm1.f`/`gtdmctl.f`) will be submitted to `Molcas/OpenMolcas` once this PR is merged.