### PR TITLE
fix: pre-compression guard and l2r_compress invariant to prevent SVD crash in MPSSI

### DIFF
--- a/dmrg/framework/dmrg/mp_tensors/compression.h
+++ b/dmrg/framework/dmrg/mp_tensors/compression.h
@@ -63,6 +63,14 @@ static l2r_compress(MPS<Matrix, SymmGroup> mps, std::size_t Mmax, double cutoff,
 {
   int L = mps.length();
   auto initialNorm = norm(mps);
+  // Guard: dividing by sqrt(0) produces Inf tensors; subsequent SVD aborts on strict LAPACK
+  // implementations (e.g. NAG). Callers must ensure the MPS has non-negligible norm before
+  // calling l2r_compress (see pre-compression guard in mps_rotate.h).
+  if (!(initialNorm >= 1e-14)) {
+      maquis::cerr << "l2r_compress: initialNorm=" << initialNorm
+                   << " is zero or near-zero; aborting to prevent undefined SVD behaviour" << std::endl;
+      std::abort();
+  }
   block_matrix<Matrix, SymmGroup> t;
   mps[0] /= std::sqrt(initialNorm);
   mps.canonize(1);

--- a/dmrg/framework/dmrg/mp_tensors/mps_rotate.h
+++ b/dmrg/framework/dmrg/mp_tensors/mps_rotate.h
@@ -315,16 +315,30 @@ namespace mps_rotate
             maquis::cout << "- intermediate correction MPS obtained - "<<      std::endl;
             //debug::mps_print_ci(mps, "dets.txt");
 
+            // Pre-compression guard: if mps_prime is already negligible before compression
+            // (e.g. incompatible charge sectors between spin manifolds in MPSSI — exact
+            // symmetry zero), calling l2r_compress would divide by sqrt(0) → Inf tensors →
+            // SVD abort on strict LAPACK implementations (NAG, some OpenBLAS builds).
+            // A negligible first correction implies a negligible second correction; skip both.
+            // mps has already been extended by join(mps, mps_prime_zero); compress_mps(mps)
+            // below discards the zero contribution via SVD cutoff, recovering the original mps.
+            // NOTE: use !(>= threshold) to catch NaN via IEEE 754 (NaN comparisons are false).
+            if (!(norm(mps_prime) >= 1e-14)) {
+                compress_mps<Matrix, SymmGroup>(mps, "MPS final");
+                typename Matrix::value_type n = norm(mps_prime);
+                maquis::cout << "-  First correction negligible before compression (norm=" << n
+                             << " < 1e-14); skipping  -" << std::endl;
+                maquis::cout << "-  Final (for the current site to be rotated) MPS with full compression - " << std::endl;
+                continue;
+            }
+
             // compression of MPS'
             compress_mps<Matrix, SymmGroup>(mps_prime, "MPS prime");
 
-            // Guard: if the first correction vanishes or becomes NaN after compression,
-            // applying the MPO to it produces mps_prime_prime with disconnected charge sectors
-            // or NaN tensors; the subsequent join/multiply_by_scalar causes a SIGSEGV
-            // (qcscine/qcmaquis#36). A negligible/NaN first correction implies a negligible
-            // second correction, so skip both.
-            // NOTE: use !(>= threshold) instead of (< threshold) to also catch NaN, since
-            // IEEE 754 defines NaN < x == false for any x, bypassing a plain < guard.
+            // Post-compression guard: mps_prime may become NaN after compression due to
+            // degenerate charge sectors (qcscine/qcmaquis#36). Catches NaN that only appears
+            // after SVD truncation on near-degenerate sectors.
+            // NOTE: use !(>= threshold) to catch NaN via IEEE 754.
             if (!(norm(mps_prime) >= 1e-14)) {
                 compress_mps<Matrix, SymmGroup>(mps, "MPS final");
                 typename Matrix::value_type n = norm(mps_prime);


### PR DESCRIPTION
## Summary

- Add pre-compression norm guard in `mps_rotate.h` before `compress_mps(mps_prime)` in the MPSSI MPS rotation loop
- Add permanent invariant guard in `compression.h` inside `l2r_compress` (ttrace overload)

## Problem

After PR #41 (post-compression NaN guard, closes #36), a new crash was identified in CI: **SIGABRT (rc=-6)** inside `l2r_compress` during the second quintet MPS rotation.

The existing post-compression guard fires only after `compress_mps` returns. When `mps_prime` has zero or near-zero norm before compression (incompatible charge sectors between spin manifolds, e.g. quintet MPS in singlet basis, exact symmetry zero), `l2r_compress` computes:

```cpp
mps[0] /= std::sqrt(initialNorm);  // divide by sqrt(0) → Inf
mps.canonize(1);                    // SVD on Inf-containing matrix
```

On NAG LAPACK (CI), `xerbla("DGESDD", ...)` → `abort()` → SIGABRT. `compress_mps` never returns, the post-compression guard can never fire. On Intel MKL (local), SVD on Inf returns NaN silently, no crash.

Pre-compression norms observed at affected MPSSI rotation sites: 3.4e-22, 2.9e-19, -1.4e-35 (negative due to fp noise in near-zero dot product → `sqrt(negative) = NaN` → all-NaN tensors → SVD abort on any LAPACK).

## Fix

**`mps_rotate.h`:** Pre-compression guard immediately before `compress_mps(mps_prime, "MPS prime")`. Uses `!(norm >= 1e-14)` to catch zero, near-zero, and NaN via IEEE 754. A zero/negligible first correction implies a zero/negligible second correction; both are safely skipped. The `join(mps, mps_prime_zero)` already executed is cleaned up by `compress_mps(mps, "MPS final")` via SVD cutoff.

The existing post-compression guard (PR #41) is retained: it handles the complementary case where compression on near-degenerate sectors produces NaN.

**`compression.h`:** Permanent invariant guard in `l2r_compress(mps, Mmax, cutoff, ttrace)`. Makes the contract explicit: callers must ensure non-negligible norm. Fires immediately with a clear message if the pre-compression guard fails (future regressions), rather than silently corrupting tensors with Inf/NaN.

## Verification

Crash reproduced locally by injecting abort in `l2r_compress` at `initialNorm < 1e-14`  rc=-6 at `initialNorm=3.40742e-22`, exact CI signature. Fix confirmed: pre-compression guard fires for all near-zero cases; `l2r_compress` abort never reached; `test qcmaquis:017` passes.

Output with fix applied:
```
-  First correction negligible before compression (norm=3.40742e-22 < 1e-14); skipping  -
-  First correction negligible before compression (norm=-1.40468e-35 < 1e-14); skipping  -
-  First correction negligible (norm=2.80729e-17 < 1e-14); skipping second correction  -
```

## Test plan

- [ ] `test qcmaquis:017` passes (C2H2 CAS(4,4)/cc-pVDZ, 3 roots/spin, LumOrb, NEVPT2, MPSSI QDSC+SpinOrbit), see https://gitlab.com/Molcas/OpenMolcas/-/merge_requests/860